### PR TITLE
Small fix to the ouptut of a generated app

### DIFF
--- a/app/parts/00_base.ls
+++ b/app/parts/00_base.ls
@@ -22,4 +22,4 @@ module.exports =
 
     main: ->
       @config.save!
-      console.log 'Your Arch app has been generated! Use \'arch s\'  to run it.'
+      console.log 'Your Arch app has been generated! Use \'arch-cli s\'  to run it.'


### PR DESCRIPTION
Just followed the steps for using the generator an noticed that the output shows:

```Your Arch app has been generated! Use 'arch s'  to run it.```

I got `arch: Can't find s in PATH`. Going to back to the documentation I saw that you actually needed to type `arch-cli`. So I thought I would update this.