### PR TITLE
Make npm 'main' script language agnostic

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -1,7 +1,7 @@
 {
   "name": "arch-app",
   "version": "0.0.0",
-  "main": "app/app.ls",
+  "main": "app/app",
   "scripts": {},
   "dependencies": {
     "LiveScript": "^1.3.1",


### PR DESCRIPTION
Previously the generated template does not allow `arch-cli s` to actually start the application when using an es6 template, because the 'main' script in the package.json had the '.ls' extension and is therefore not recognised by node unless using LiveScript.

This pull request makes the request language agnostic as far as `arch-cli s` is concerned.

(Tested with es6 and ls versions on node v0.12.2).